### PR TITLE
Change psi bound from minusPi to zero

### DIFF
--- a/pdetclassifier.py
+++ b/pdetclassifier.py
@@ -67,7 +67,7 @@ def lookup_limits():
         'iota'  : [0,np.pi],
         'ra'    : [-np.pi,np.pi],
         'dec'   : [-np.pi/2,np.pi/2],
-        'psi'   : [-np.pi,np.pi]
+        'psi'   : [0,np.pi]
         }
 
     return limits
@@ -87,8 +87,8 @@ def generate_binaries(N):
     for var in ['mtot','q','z']:
         binaries[var]=np.random.uniform(min(limits[var]),max(limits[var]),N)
     binaries['iota']= np.arccos(np.random.uniform(-1,1,N))
-    for var in ['ra','psi']:
-        binaries[var]= np.pi*np.random.uniform(-1,1,N)
+    binaries['psi']= np.pi*np.random.uniform(0,1,N)
+    binaries['ra']= np.pi*np.random.uniform(-1,1,N)
     binaries['dec']= np.arccos(np.random.uniform(-1,1,N))- np.pi/2
 
     mag = np.random.uniform(0,1,N)
@@ -374,7 +374,7 @@ def pdet(model,binaries, Nmc = 10000):
     extrinsic={}
     extrinsic['iota'] =  np.arccos(np.random.uniform(-1,1,Nmc))
     extrinsic['ra']   =  np.pi*np.random.uniform(-1,1,Nmc)
-    extrinsic['psi']  =  np.pi*np.random.uniform(-1,1,Nmc)
+    extrinsic['psi']  =  np.pi*np.random.uniform(0,1,Nmc)
     extrinsic['dec']  =  np.arccos(np.random.uniform(-1,1,Nmc))- np.pi/2
 
     # Inflate the array with the intrisinc variables


### PR DESCRIPTION
The polarization angle Psi is cyclic over a span of pi radians (rather than 2pi), so you can get the same physics with drawing points in [0, pi] as you get with points in [-pi, pi].
This change should give the same pDet network sensitivity, but potentially using fewer input points (I doubt it'll make a super big difference though).